### PR TITLE
Temporarily Set Default Backend to “CPU” and Disable “MTK” Native Library Loading

### DIFF
--- a/Breeze2-android-demo/app/build.gradle.kts
+++ b/Breeze2-android-demo/app/build.gradle.kts
@@ -14,7 +14,7 @@ android {
         minSdk = 31
         targetSdk = 35
         versionCode = 1
-        versionName = "release.0.1"
+        versionName = "0.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -25,8 +25,7 @@ android {
             abiFilters.addAll(listOf("arm64-v8a"))
         }
 
-        // Set default app name in manifest placeholders
-        manifestPlaceholders["app_name"] = "GAI Android"
+        manifestPlaceholders["app_name"] = "Breeze2-demo"
     }
 
     buildTypes {
@@ -40,8 +39,8 @@ android {
     }
 
     buildFeatures {
-        buildConfig = true  // Enable BuildConfig generation
-        viewBinding = true  // Keep existing viewBinding
+        buildConfig = true
+        viewBinding = true
     }
 
     compileOptions {
@@ -64,13 +63,6 @@ android {
         }
     }
 
-    // TODO: refactor this, currently used for MTK NPU support
-    // externalNativeBuild {
-    //     cmake {
-    //         path = File("src/main/cpp/CMakeLists.txt")
-    //     }
-    // }
-
     packaging {
         jniLibs {
             useLegacyPackaging = true
@@ -79,150 +71,52 @@ android {
 
     flavorDimensions += "version"
     productFlavors {
-        create("rel") {
+        create("breeze") {
             dimension = "version"
-            applicationIdSuffix = ".release"
-            versionNameSuffix = "-release"
+            applicationIdSuffix = ".breeze"
+            versionNameSuffix = "-breeze"
             resValue("string", "app_name", "Breeze2-demo")
             buildConfigField("String", "GIT_BRANCH", "\"release/0.1\"")
             manifestPlaceholders["file_provider_authority"] = 
-                "com.mtkresearch.gai_android.release.fileprovider"
-        }
-        create("llm") {
-            dimension = "version"
-            applicationIdSuffix = ".llm"
-            versionNameSuffix = "-llm"
-            resValue("string", "app_name", "GAI-LLM")
-            buildConfigField("String", "GIT_BRANCH", "\"llm_cpu\"")
-            manifestPlaceholders["file_provider_authority"] = 
-                "com.mtkresearch.gai_android.llm.fileprovider"
-        }
-        create("vlm") {
-            dimension = "version"
-            applicationIdSuffix = ".vlm"
-            versionNameSuffix = "-vlm"
-            resValue("string", "app_name", "GAI-VLM")
-            buildConfigField("String", "GIT_BRANCH", "\"vlm_cpu\"")
-            manifestPlaceholders["file_provider_authority"] = 
-                "com.mtkresearch.gai_android.vlm.fileprovider"
-        }
-        create("mtk") {
-            dimension = "version"
-            applicationIdSuffix = ".mtk"
-            versionNameSuffix = "-mtk"
-            resValue("string", "app_name", "GAI-MTK")
-            buildConfigField("String", "GIT_BRANCH", "\"mtk\"")
-            manifestPlaceholders["file_provider_authority"] = 
-                "com.mtkresearch.gai_android.mtk.fileprovider"
-        }
-        create("full") {
-            dimension = "version"
-            applicationIdSuffix = ".full"
-            versionNameSuffix = "-full"
-            resValue("string", "app_name", "GAI-Full")
-            buildConfigField("String", "GIT_BRANCH", "\"main\"")
-            manifestPlaceholders["file_provider_authority"] = 
-                "com.mtkresearch.gai_android.full.fileprovider"
-        }
-        create("dev") {
-            dimension = "version"
-            applicationIdSuffix = ".dev"
-            versionNameSuffix = "-dev"
-            resValue("string", "app_name", "GAI-dev")
-            buildConfigField("String", "GIT_BRANCH", "\"dev\"")
-            manifestPlaceholders["file_provider_authority"] = 
-                "com.mtkresearch.gai_android.dev.fileprovider"
-        }
-        create("cpu") {
-            dimension = "version"
-            applicationIdSuffix = ".cpu"
-            versionNameSuffix = "-cpu"
-            resValue("string", "app_name", "GAI-CPU")
-            buildConfigField("String", "GIT_BRANCH", "\"cpu\"")
-            manifestPlaceholders["file_provider_authority"] = 
-                "com.mtkresearch.gai_android.cpu.fileprovider"
-        }
-        create("add_warning") {
-            dimension = "version"
-            applicationIdSuffix = ".add_warning"
-            versionNameSuffix = "-add_warning"
-            resValue("string", "app_name", "GAI-Warning")
-            buildConfigField("String", "GIT_BRANCH", "\"add_warning\"")
-            manifestPlaceholders["file_provider_authority"] = 
-                "com.mtkresearch.gai_android.add_warning.fileprovider"
+                "com.mtkresearch.gai_android.breeze.fileprovider"
         }
     }
+}
 
-//    sourceSets.getByName("main") {
-//        jniLibs.setSrcDirs(listOf("src/main/libs"))
-//    }
+// Version constants
+object Versions {
+    const val CORE_KTX = "1.12.0"
+    const val APPCOMPAT = "1.6.1"
+    const val MATERIAL = "1.11.0"
+    const val CONSTRAINT_LAYOUT = "2.1.4"
+    const val COROUTINES = "1.7.3"
+    const val JUNIT = "4.13.2"
+    const val ANDROID_JUNIT = "1.1.5"
+    const val ESPRESSO = "3.5.1"
+    const val FBJNI = "0.5.1"
+    const val GSON = "2.8.6"
+    const val SOLOADER = "0.10.5"
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.12.0")
-    implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("com.google.android.material:material:1.11.0")
-    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    // AndroidX Core
+    implementation("androidx.core:core-ktx:${Versions.CORE_KTX}")
+    implementation("androidx.appcompat:appcompat:${Versions.APPCOMPAT}")
+    implementation("com.google.android.material:material:${Versions.MATERIAL}")
+    implementation("androidx.constraintlayout:constraintlayout:${Versions.CONSTRAINT_LAYOUT}")
     
     // Kotlin coroutines
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.COROUTINES}")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.COROUTINES}")
 
     // Testing
-    testImplementation("junit:junit:4.13.2")
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    testImplementation("junit:junit:${Versions.JUNIT}")
+    androidTestImplementation("androidx.test.ext:junit:${Versions.ANDROID_JUNIT}")
+    androidTestImplementation("androidx.test.espresso:espresso-core:${Versions.ESPRESSO}")
 
-    // Executorch
-    implementation("com.facebook.fbjni:fbjni:0.5.1")
-    implementation("com.google.code.gson:gson:2.8.6")
-    implementation("com.facebook.soloader:soloader:0.10.5")
+    // Executorch dependencies
+    implementation("com.facebook.fbjni:fbjni:${Versions.FBJNI}")
+    implementation("com.google.code.gson:gson:${Versions.GSON}")
+    implementation("com.facebook.soloader:soloader:${Versions.SOLOADER}")
     implementation(files("libs/executorch.aar"))
-
-    // Add explicit dependency for Sherpa native libraries
-//    implementation(fileTree(mapOf(
-//        "dir" to "../libs",
-//        "include" to listOf(
-//            "*.so"
-//        )
-//    )))
-}
-
-// Git Branch Switch Task
-tasks.register("switchGitBranch") {
-    doLast {
-        val selectedFlavor = project.gradle.startParameter.taskRequests
-            .flatMap { it.args }
-            .firstOrNull { it.contains("assemble") && 
-                (it.contains("Llm") || it.contains("Vlm") || 
-                 it.contains("Full") || it.contains("dev") ||
-                 it.contains("Mtk") || it.contains("add_warning") ||
-                 it.contains("Rel") || it.contains("Cpu")) }
-            ?.let { task ->
-                when {
-                    task.contains("Rel") -> "release/0.1"
-                    task.contains("Llm") -> "llm_cpu"
-                    task.contains("Vlm") -> "vlm_cpu"
-                    task.contains("Mtk") -> "mtk"
-                    task.contains("Full") -> "main"
-                    task.contains("dev") -> "dev"
-                    task.contains("Cpu") -> "cpu"
-                    task.contains("add_warning") -> "add_warning"
-                    else -> null
-                }
-            }
-
-        selectedFlavor?.let {
-            exec {
-                commandLine("git", "checkout", it)
-            }
-        }
-    }
-}
-
-// Make assemble tasks depend on switchGitBranch
-tasks.whenTaskAdded {
-    if (name.startsWith("assemble")) {
-        dependsOn("switchGitBranch")
-    }
 }

--- a/Breeze2-android-demo/app/src/main/java/com/mtkresearch/gai_android/ChatActivity.java
+++ b/Breeze2-android-demo/app/src/main/java/com/mtkresearch/gai_android/ChatActivity.java
@@ -591,7 +591,7 @@ public class ChatActivity extends AppCompatActivity implements ChatMessageAdapte
                 }
             }).thenAccept(finalResponse -> {
                 runOnUiThread(() -> {
-                    if (finalResponse != null && !finalResponse.equals(LLMEngineService.DEFAULT_ERROR_RESPONSE)) {
+                    if (finalResponse != null && !finalResponse.equals(AppConstants.LLM_DEFAULT_ERROR_RESPONSE)) {
                         String response = finalResponse.trim();
                         // Only update with error message if we haven't received any real response
                         if (response.isEmpty() && !aiMessage.hasContent()) {

--- a/Breeze2-android-demo/app/src/main/java/com/mtkresearch/gai_android/MainActivity.java
+++ b/Breeze2-android-demo/app/src/main/java/com/mtkresearch/gai_android/MainActivity.java
@@ -684,9 +684,10 @@ public class MainActivity extends AppCompatActivity {
         // Setup backend spinner
         List<String> backendOptions = new ArrayList<>();
         backendOptions.add("cpu");  // CPU backend is always available
-        if (LLMEngineService.isMTKBackendAvailable()) {
-            backendOptions.add("mtk");
-        }
+        // Disable MTK backend option for now
+        // if (LLMEngineService.isMTKBackendAvailable()) {
+        //     backendOptions.add("mtk");
+        // }
         
         backendAdapter = new ArrayAdapter<>(this, 
             android.R.layout.simple_spinner_item, backendOptions);
@@ -695,7 +696,7 @@ public class MainActivity extends AppCompatActivity {
 
         // Load saved settings
         float savedTemp = settings.getFloat(AppConstants.KEY_TEMPERATURE, 0.0f);
-        String savedBackend = settings.getString(AppConstants.KEY_PREFERRED_BACKEND, "cpu");
+        String savedBackend = settings.getString(AppConstants.KEY_PREFERRED_BACKEND, AppConstants.DEFAULT_BACKEND);
         
         temperatureInput.setText(String.valueOf(savedTemp));
         int backendPosition = backendAdapter.getPosition(savedBackend);

--- a/Breeze2-android-demo/app/src/main/java/com/mtkresearch/gai_android/service/LLMEngineService.java
+++ b/Breeze2-android-demo/app/src/main/java/com/mtkresearch/gai_android/service/LLMEngineService.java
@@ -11,6 +11,7 @@ import com.executorch.PromptFormat;
 import com.executorch.ModelType;
 import com.mtkresearch.gai_android.utils.ChatMessage;
 import com.mtkresearch.gai_android.utils.ConversationManager;
+import com.mtkresearch.gai_android.utils.AppConstants;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -22,77 +23,72 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.List;
 
 public class LLMEngineService extends BaseEngineService {
-    private static boolean MTK_BACKEND_AVAILABLE = false;
+    private static final String TAG = "LLMEngineService";
+    
+    // Service state
+    private String currentBackend = "none";
+    private String preferredBackend = AppConstants.BACKEND_DEFAULT;
+    private boolean hasSeenAssistantMarker = false;
+    private final ConversationManager conversationManager;
+    
+    // Generation state
+    private final AtomicBoolean isGenerating = new AtomicBoolean(false);
+    private CompletableFuture<String> currentResponse = new CompletableFuture<>();
+    private StreamingResponseCallback currentCallback = null;
+    private final StringBuilder currentStreamingResponse = new StringBuilder();
+    private ExecutorService executor;
+    
+    // CPU backend (LlamaModule)
+    private LlamaModule mModule = null;
+    private String modelPath = null;  // Set from intent
+    
+    // MTK backend state
     private static final Object MTK_LOCK = new Object();
     private static int mtkInitCount = 0;
-    private static final int MAX_MTK_INIT_ATTEMPTS = 5;
     private static boolean isCleaningUp = false;
-    private static final long CLEANUP_TIMEOUT_MS = 5000; // 5 seconds timeout for cleanup
-    
     private static final ExecutorService cleanupExecutor = Executors.newSingleThreadExecutor();
-    private static final long NATIVE_OP_TIMEOUT_MS = 2000; // 2 seconds timeout for native operations
     
     static {
-        try {
-            // Load libraries in order
-            System.loadLibrary("sigchain");  // Load signal handler first
-            Thread.sleep(100);  // Give time for signal handlers to initialize
-            
-            System.loadLibrary("llm_jni");
-            MTK_BACKEND_AVAILABLE = true;
-            Log.d("LLMEngineService", "Successfully loaded llm_jni library");
-            
-            // Register shutdown hook for cleanup
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-                try {
-                    cleanupMTKResources();
-                    cleanupExecutor.shutdownNow();
-                } catch (Exception e) {
-                    Log.e("LLMEngineService", "Error in shutdown hook", e);
-                }
-            }));
-        } catch (UnsatisfiedLinkError | Exception e) {
-            MTK_BACKEND_AVAILABLE = false;
-            Log.w("LLMEngineService", "Failed to load native libraries, MTK backend will be disabled", e);
+        // Only try to load MTK libraries if MTK backend is enabled
+        if (AppConstants.MTK_BACKEND_ENABLED) {
+            try {
+                // Load libraries in order
+                System.loadLibrary("sigchain");  // Load signal handler first
+                Thread.sleep(100);  // Give time for signal handlers to initialize
+                
+                System.loadLibrary("llm_jni");
+                AppConstants.MTK_BACKEND_AVAILABLE = true;
+                Log.d(TAG, "Successfully loaded llm_jni library");
+                
+                // Register shutdown hook for cleanup
+                Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                    try {
+                        cleanupMTKResources();
+                        cleanupExecutor.shutdownNow();
+                    } catch (Exception e) {
+                        Log.e(TAG, "Error in shutdown hook", e);
+                    }
+                }));
+            } catch (UnsatisfiedLinkError | Exception e) {
+                AppConstants.MTK_BACKEND_AVAILABLE = false;
+                Log.w(TAG, "Failed to load native libraries, MTK backend will be disabled", e);
+            }
+        } else {
+            Log.i(TAG, "MTK backend is disabled in AppConstants");
         }
     }
 
-    // Add static method to check MTK backend availability
     public static boolean isMTKBackendAvailable() {
-        return MTK_BACKEND_AVAILABLE;
+        return AppConstants.MTK_BACKEND_AVAILABLE && AppConstants.MTK_BACKEND_ENABLED;
     }
 
-    private static final String TAG = "LLMEngineService";
-    private static final long INIT_TIMEOUT_MS = 120000;
-    private static final long GENERATION_TIMEOUT_MS = 60000;  // Increased timeout
-    public static final String DEFAULT_ERROR_RESPONSE = "[!!!] LLM engine backend failed";
-    private String backend = "none";
-    private String preferredBackend = "cpu";  // Default to CPU backend
-    
-    // Local CPU backend (LlamaModule)
-    private LlamaModule mModule = null;
-    private static final String TOKENIZER_PATH = "/data/local/tmp/llama/tokenizer.bin";
-    private static final float TEMPERATURE = 0.8f;
-    private String modelPath = null;  // Will be set from intent
-    private CompletableFuture<String> currentResponse = new CompletableFuture<>();
-    private StreamingResponseCallback currentCallback = null;
-    private StringBuilder currentStreamingResponse = new StringBuilder();
-    private boolean hasSeenAssistantMarker = false;
-    private ExecutorService executor;
-    private AtomicBoolean isGenerating = new AtomicBoolean(false);
-    private final ConversationManager conversationManager;
-
-    // Add method to get model name
     public String getModelName() {
-        // If no model path is set, check if we're using MTK backend
         if (modelPath == null) {
-            if (backend.equals("mtk")) {
+            if (currentBackend.equals(AppConstants.BACKEND_MTK)) {
                 return "Breeze2";  // Default to Breeze2 for MTK backend
             }
             return "Unknown";
         }
-        
-        // For CPU backend or when model path is available
         return com.mtkresearch.gai_android.utils.ModelUtils.getModelDisplayName(modelPath);
     }
 
@@ -147,7 +143,7 @@ public class LLMEngineService extends BaseEngineService {
         CompletableFuture<Boolean> future = new CompletableFuture<>();
         
         // Create a timeout future
-        CompletableFuture.delayedExecutor(INIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        CompletableFuture.delayedExecutor(AppConstants.LLM_INIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
             .execute(() -> {
                 if (!future.isDone()) {
                     future.complete(false);
@@ -167,7 +163,7 @@ public class LLMEngineService extends BaseEngineService {
                     Thread.sleep(200);
                     
                     if (initializeMTKBackend()) {
-                        backend = "mtk";
+                        currentBackend = "mtk";
                         isInitialized = true;
                         Log.d(TAG, "Successfully initialized MTK backend");
                         future.complete(true);
@@ -182,7 +178,7 @@ public class LLMEngineService extends BaseEngineService {
                 // Try CPU backend if MTK failed or CPU is preferred
                 if (preferredBackend.equals("cpu") || preferredBackend.equals("localCPU")) {
                     if (initializeLocalCPUBackend()) {
-                        backend = "localCPU";
+                        currentBackend = "localCPU";
                         isInitialized = true;
                         Log.d(TAG, "Successfully initialized CPU backend");
                         future.complete(true);
@@ -308,7 +304,7 @@ public class LLMEngineService extends BaseEngineService {
     }
 
     private boolean initializeMTKBackend() {
-        if (!MTK_BACKEND_AVAILABLE) {
+        if (!AppConstants.MTK_BACKEND_AVAILABLE) {
             Log.d(TAG, "MTK backend disabled, skipping");
             return false;
         }
@@ -419,10 +415,10 @@ public class LLMEngineService extends BaseEngineService {
 
             // Initialize LlamaModule with model parameters
             mModule = new LlamaModule(
-                ModelUtils.getModelCategory(ModelType.LLAMA_3_2),  // Using LLAMA_3_2 model type
+                ModelUtils.getModelCategory(ModelType.LLAMA_3_2),
                 modelPath,
-                TOKENIZER_PATH,
-                TEMPERATURE
+                AppConstants.LLM_TOKENIZER_PATH,
+                AppConstants.LLM_TEMPERATURE
             );
 
             // Load the model
@@ -442,12 +438,12 @@ public class LLMEngineService extends BaseEngineService {
 
     public CompletableFuture<String> generateResponse(String prompt) {
         if (!isInitialized) {
-            return CompletableFuture.completedFuture(DEFAULT_ERROR_RESPONSE);
+            return CompletableFuture.completedFuture(AppConstants.LLM_ERROR_RESPONSE);
         }
 
         return CompletableFuture.supplyAsync(() -> {
             try {
-                switch (backend) {
+                switch (currentBackend) {
                     case "mtk":
                         String response = nativeInference(prompt, 256, false);
                         nativeResetLlm();
@@ -479,11 +475,11 @@ public class LLMEngineService extends BaseEngineService {
                         
                         return future.get(GENERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
                     default:
-                        return DEFAULT_ERROR_RESPONSE;
+                        return AppConstants.LLM_ERROR_RESPONSE;
                 }
             } catch (Exception e) {
                 Log.e(TAG, "Error generating response", e);
-                return DEFAULT_ERROR_RESPONSE;
+                return AppConstants.LLM_ERROR_RESPONSE;
             }
         });
     }
@@ -491,9 +487,9 @@ public class LLMEngineService extends BaseEngineService {
     public CompletableFuture<String> generateStreamingResponse(String prompt, StreamingResponseCallback callback) {
         if (!isInitialized) {
             if (callback != null) {
-                callback.onToken(DEFAULT_ERROR_RESPONSE);
+                callback.onToken(AppConstants.LLM_ERROR_RESPONSE);
             }
-            return CompletableFuture.completedFuture(DEFAULT_ERROR_RESPONSE);
+            return CompletableFuture.completedFuture(AppConstants.LLM_ERROR_RESPONSE);
         }
 
         hasSeenAssistantMarker = false;
@@ -504,7 +500,7 @@ public class LLMEngineService extends BaseEngineService {
         
         return CompletableFuture.supplyAsync(() -> {
             try {
-                switch (backend) {
+                switch (currentBackend) {
                     case "mtk":
                         try {
                             // MTK backend uses raw prompt without formatting
@@ -606,18 +602,18 @@ public class LLMEngineService extends BaseEngineService {
                         
                     default:
                         if (callback != null) {
-                            callback.onToken(DEFAULT_ERROR_RESPONSE);
+                            callback.onToken(AppConstants.LLM_ERROR_RESPONSE);
                         }
-                        currentResponse.complete(DEFAULT_ERROR_RESPONSE);
-                        return DEFAULT_ERROR_RESPONSE;
+                        currentResponse.complete(AppConstants.LLM_ERROR_RESPONSE);
+                        return AppConstants.LLM_ERROR_RESPONSE;
                 }
             } catch (Exception e) {
                 Log.e(TAG, "Error in streaming response", e);
                 if (callback != null) {
-                    callback.onToken(DEFAULT_ERROR_RESPONSE);
+                    callback.onToken(AppConstants.LLM_ERROR_RESPONSE);
                 }
-                currentResponse.complete(DEFAULT_ERROR_RESPONSE);
-                return DEFAULT_ERROR_RESPONSE;
+                currentResponse.complete(AppConstants.LLM_ERROR_RESPONSE);
+                return AppConstants.LLM_ERROR_RESPONSE;
             }
         });
     }
@@ -637,7 +633,7 @@ public class LLMEngineService extends BaseEngineService {
     public void stopGeneration() {
         isGenerating.set(false);
         
-        if (backend.equals("mtk")) {
+        if (currentBackend.equals("mtk")) {
             try {
                 nativeResetLlm();
             } catch (Exception e) {
@@ -676,7 +672,7 @@ public class LLMEngineService extends BaseEngineService {
                 stopGeneration();
                 
                 // Release MTK resources if using MTK backend
-                if (backend.equals("mtk")) {
+                if (currentBackend.equals("mtk")) {
                     try {
                         // Add delay before cleanup
                         Thread.sleep(100);
@@ -703,7 +699,7 @@ public class LLMEngineService extends BaseEngineService {
                 }
                 
                 // Reset state
-                backend = "none";
+                currentBackend = "none";
                 isInitialized = false;
                 System.gc(); // Request garbage collection
                 
@@ -746,7 +742,7 @@ public class LLMEngineService extends BaseEngineService {
     }
 
     public String getCurrentBackend() {
-        return backend;
+        return currentBackend;
     }
 
     public String getPreferredBackend() {

--- a/Breeze2-android-demo/app/src/main/java/com/mtkresearch/gai_android/service/LLMEngineService.java
+++ b/Breeze2-android-demo/app/src/main/java/com/mtkresearch/gai_android/service/LLMEngineService.java
@@ -219,7 +219,7 @@ public class LLMEngineService extends BaseEngineService {
                 });
                 
                 try {
-                    resetFuture.get(NATIVE_OP_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                    resetFuture.get(AppConstants.MTK_NATIVE_OP_TIMEOUT_MS, TimeUnit.MILLISECONDS);
                 } catch (TimeoutException e) {
                     Log.w("LLMEngineService", "Reset operation timed out");
                     resetFuture.cancel(true);
@@ -237,7 +237,7 @@ public class LLMEngineService extends BaseEngineService {
                 });
                 
                 try {
-                    releaseFuture.get(NATIVE_OP_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                    releaseFuture.get(AppConstants.MTK_NATIVE_OP_TIMEOUT_MS, TimeUnit.MILLISECONDS);
                 } catch (TimeoutException e) {
                     Log.w("LLMEngineService", "Release operation timed out");
                     releaseFuture.cancel(true);
@@ -279,7 +279,7 @@ public class LLMEngineService extends BaseEngineService {
                     });
                     
                     try {
-                        cleanupFuture.get(NATIVE_OP_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                        cleanupFuture.get(AppConstants.MTK_NATIVE_OP_TIMEOUT_MS, TimeUnit.MILLISECONDS);
                     } catch (TimeoutException e) {
                         Log.w(TAG, "Cleanup attempt " + (i+1) + " timed out");
                         cleanupFuture.cancel(true);
@@ -317,7 +317,7 @@ public class LLMEngineService extends BaseEngineService {
 
             try {
                 // Force cleanup if we've hit the max init attempts
-                if (mtkInitCount >= MAX_MTK_INIT_ATTEMPTS) {
+                if (mtkInitCount >= AppConstants.MAX_MTK_INIT_ATTEMPTS) {
                     Log.w(TAG, "MTK init count exceeded limit, forcing cleanup");
                     forceCleanupMTKResources();
                     mtkInitCount = 0;
@@ -388,7 +388,7 @@ public class LLMEngineService extends BaseEngineService {
             });
             
             cleanupThread.start();
-            cleanupThread.join(CLEANUP_TIMEOUT_MS);
+            cleanupThread.join(AppConstants.MTK_CLEANUP_TIMEOUT_MS);
             
             if (cleanupThread.isAlive()) {
                 Log.w(TAG, "Cleanup thread timed out, interrupting");
@@ -473,7 +473,7 @@ public class LLMEngineService extends BaseEngineService {
                             }, false);
                         });
                         
-                        return future.get(GENERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                        return future.get(AppConstants.LLM_GENERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
                     default:
                         return AppConstants.LLM_ERROR_RESPONSE;
                 }
@@ -538,7 +538,7 @@ public class LLMEngineService extends BaseEngineService {
                                 }
                             });
                             
-                            return currentResponse.get(GENERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                            return currentResponse.get(AppConstants.LLM_GENERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
                         } catch (Exception e) {
                             Log.e(TAG, "Error in MTK streaming response", e);
                             throw e;
@@ -598,7 +598,7 @@ public class LLMEngineService extends BaseEngineService {
                             }
                         });
                         
-                        return currentResponse.get(GENERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                        return currentResponse.get(AppConstants.LLM_GENERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS);
                         
                     default:
                         if (callback != null) {
@@ -727,7 +727,7 @@ public class LLMEngineService extends BaseEngineService {
         });
         
         try {
-            cleanupFuture.get(CLEANUP_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            cleanupFuture.get(AppConstants.MTK_CLEANUP_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         } catch (TimeoutException e) {
             Log.w(TAG, "Service cleanup timed out");
             cleanupFuture.cancel(true);

--- a/Breeze2-android-demo/app/src/main/java/com/mtkresearch/gai_android/utils/AppConstants.java
+++ b/Breeze2-android-demo/app/src/main/java/com/mtkresearch/gai_android/utils/AppConstants.java
@@ -36,6 +36,10 @@ public class AppConstants {
     // LLM Service Constants
     public static final long LLM_INIT_TIMEOUT_MS = 120000;  // 2 minutes
     public static final long LLM_GENERATION_TIMEOUT_MS = 60000;  // 1 minute
+    public static final long LLM_NATIVE_OP_TIMEOUT_MS = 2000;  // 2 seconds
+    public static final long LLM_CLEANUP_TIMEOUT_MS = 5000;  // 5 seconds
+    public static final int LLM_MAX_MTK_INIT_ATTEMPTS = 3;
+    public static final String LLM_DEFAULT_ERROR_RESPONSE = "I apologize, but I encountered an error generating a response. Please try again.";
     public static final String LLM_ERROR_RESPONSE = "[!!!] LLM engine backend failed";
     public static final String LLM_TOKENIZER_PATH = "/data/local/tmp/llama/tokenizer.bin";
     public static final float LLM_TEMPERATURE = 0.8f;

--- a/Breeze2-android-demo/app/src/main/java/com/mtkresearch/gai_android/utils/AppConstants.java
+++ b/Breeze2-android-demo/app/src/main/java/com/mtkresearch/gai_android/utils/AppConstants.java
@@ -11,12 +11,34 @@ public class AppConstants {
     public static final String KEY_FIRST_LAUNCH = "first_launch";
     public static final String KEY_TEMPERATURE = "temperature";
     public static final String KEY_PREFERRED_BACKEND = "preferred_backend";
+    public static final String DEFAULT_BACKEND = "cpu";  // Default to CPU backend
     
     // Service Enable Flags
     public static final boolean LLM_ENABLED = true;  // LLM is essential
     public static final boolean VLM_ENABLED = false; // VLM is experimental
     public static final boolean ASR_ENABLED = false; // ASR requires permission
     public static final boolean TTS_ENABLED = true;  // TTS is stable
+    
+    // Backend Enable Flags
+    public static final boolean MTK_BACKEND_ENABLED = false;  // Set to true to enable MTK backend
+    public static volatile boolean MTK_BACKEND_AVAILABLE = false;  // Runtime state of MTK backend availability
+    
+    // Backend Constants
+    public static final String BACKEND_CPU = "cpu";
+    public static final String BACKEND_MTK = "mtk";
+    public static final String BACKEND_DEFAULT = BACKEND_CPU;
+    
+    // MTK Backend Constants
+    public static final int MAX_MTK_INIT_ATTEMPTS = 5;
+    public static final long MTK_CLEANUP_TIMEOUT_MS = 5000;  // 5 seconds timeout for cleanup
+    public static final long MTK_NATIVE_OP_TIMEOUT_MS = 2000;  // 2 seconds timeout for native operations
+    
+    // LLM Service Constants
+    public static final long LLM_INIT_TIMEOUT_MS = 120000;  // 2 minutes
+    public static final long LLM_GENERATION_TIMEOUT_MS = 60000;  // 1 minute
+    public static final String LLM_ERROR_RESPONSE = "[!!!] LLM engine backend failed";
+    public static final String LLM_TOKENIZER_PATH = "/data/local/tmp/llama/tokenizer.bin";
+    public static final float LLM_TEMPERATURE = 0.8f;
     
     // When false: Send button always shows send icon and only sends messages
     // When true: Send button toggles between send and audio chat mode


### PR DESCRIPTION
This PR temporarily changes the default backend to “CPU” to ensure stable execution while avoiding native library loading for the “MTK” backend. The “MTK” backend is planned to be migrated with the ExecuteTorch MediaTek delegate, so for now, the app should only run with the “CPU” backend. This update prevents potential issues with incomplete migration and ensures smooth operation until the transition is complete.

> I’m planning to update the MTK backend implementation to use the [Executorch Mediatek delegates](https://github.com/pytorch/executorch/blob/main/examples/demo-apps/android/LlamaDemo/docs/delegates/mediatek_README.md) As part of this transition, I’ll temporarily remove the native library loading process, keeping only the CPU backend available for a few days. Thank you for testing! I’ll leave a comment here to track the upgrade progress. 😆 

 _Originally posted by @muxi1998 in [#10](https://github.com/mtkresearch/Breeze2-android-demo/issues/10#issuecomment-2667321442)_